### PR TITLE
Fix generic type parameter resolution in notifier build methods

### DIFF
--- a/.github/workflows/action_pull_request.yml
+++ b/.github/workflows/action_pull_request.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Run unit tests
         run: |
           dart run test test/unit
+      - name: Run integration tests
+        run: |
+          dart run build_runner test -- test/integration
       - name: Run golden tests
         run: |
           dart run build_runner test -- test/golden

--- a/.run/Golden tests.run.xml
+++ b/.run/Golden tests.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Golden tests" type="DartTestRunConfigurationType" factoryName="Dart Test">
+    <option name="filePath" value="$PROJECT_DIR$/test/golden/" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Integration tests.run.xml
+++ b/.run/Integration tests.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Integration tests" type="DartTestRunConfigurationType" factoryName="Dart Test">
+    <option name="filePath" value="$PROJECT_DIR$/test/integration/" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Run unit tests.run.xml
+++ b/.run/Run unit tests.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run unit tests" type="DartTestRunConfigurationType" factoryName="Dart Test">
+    <option name="filePath" value="$PROJECT_DIR$/test/unit" />
+    <option name="scope" value="FOLDER" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,29 +6,33 @@ We are using [GitFlow](https://www.atlassian.com/git/tutorials/comparing-workflo
 
 # Versioning
 
-This project uses semantic versioning with version 1.0 being reserved for a possible public pub.dev release in future. As such, treat increments in the "minor version" as breaking changes (i.e. 0.X.0).
+This project uses semantic versioning, read [here](https://semver.org/) for more info. 
 
 We are following the convention set out in the main Flutter SDK repository when it comes to what counts as a breaking change. The primary take away is that any change that breaks the current set of unit tests is considered a breaking change.
 
 # Testing
 
-This project is currently tested in a couple of ways to take both a fine-grained and holistic approach.
+This project is currently tested in a few ways to take both a fine-grained and holistic approach.
 
 * Unit tests - Located in `test/unit`.
+* Integration tests - Located in `test/integration`, these tests utilise the `build_test` package for code resolution and in-memory builds.
 * Golden tests - Located in `test/golden`, these take Dart code as an input and verify it against a reference output.
 
-If you are having an issue in a package that consumes this package, I would recommend contributing another golden test scenario that replicates your requirement.
+Running these all these tests locally before submission is recommended to catch any regressions.
 
 ## Running tests
 
-Due to the use of the `dart:mirrors` package, unit tests cannot be executed under Flutter (which disables introspection for performance). As such, you'll want to run the unit tests with Dart:
+Included in the project, there are a number of pre-configured test run configurations for Intellij (& Android Studio). Using these run configurations has the benefit of being able to use IDE tooling for debugging tests.
+
+Alternatively, instructions for running the tests via command line follow. Due to the use of the `dart:mirrors` package, unit tests cannot be executed under Flutter (which disables introspection for performance). As such, you'll want to run the unit tests with Dart:
 
 ```shell
 dart test test/unit
 ```
 
-As implied above, the golden tests need to use `build_runner` in order to verify the output of the code generator. Conveniently, `build_runner` provides a wrapper to orchestrate this, just use the following command.
+As implied above, the integration/golden tests need to utilise `build_runner` in order to use in-memory builds. Conveniently, `build_runner` provides a wrapper to orchestrate this, just use the following commands.
 
 ```shell
-dart run build_runner test test/golden
+dart run build_runner test -- test/integration
+dart run build_runner test -- test/golden
 ```

--- a/lib/src/util/symbol_resolver.dart
+++ b/lib/src/util/symbol_resolver.dart
@@ -15,7 +15,7 @@ class SymbolResolver extends RecursiveAstVisitor {
     }
     final (name, uri) = (element.name3, element.library2?.uri);
     if (name == null || uri == null || uri.scheme == _coreLibraryScheme) {
-      return null;
+      return super.visitNamedType(node);
     }
     _references.add(Reference(name, uri.toString()));
     return super.visitNamedType(node);

--- a/test/integration/util/symbol_resolver/smybol_resolver_test.dart
+++ b/test/integration/util/symbol_resolver/smybol_resolver_test.dart
@@ -1,0 +1,73 @@
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:flumepod/src/util/symbol_resolver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group("Symbol resolver unit tests", () {
+    late SymbolResolver sut;
+
+    setUp(() {
+      sut = SymbolResolver();
+    });
+
+    test("accept - collects named types within generics", () async {
+      /// This is a much simpler example than [SymbolResolver] would typically
+      /// encounter but the point of this test is that a reference is collected
+      /// to the [Model] class within [List].
+      await resolveSources({
+        "package|provider.g.dart": r"""
+        abstract class _$DummySource extends $AsyncNotifier<List<Model>> {
+          late final _$args = ref.$arg as int;
+          int get param => _$args;
+        
+          FutureOr<List<Model>> build(
+            int param,
+          );
+          @$mustCallSuper
+          @override
+          void runBuild() {
+            final created = build(
+              _$args,
+            );
+            final ref = this.ref as List<Model>;
+            final element = ref.element as Future<List<Model>>;
+            element.handleValue(ref, created);
+          }
+        }
+        
+        class Model {
+          final int value;
+        
+          const Model({required this.value});
+        }
+      """
+      }, (resolver) async {
+        // Setup
+        final libraryElement = await resolver.libraryFor(AssetId("package", "provider.g.dart"));
+        final classElement = libraryElement.classes.firstWhere((it) => it.name3 == r"_$DummySource");
+        final methodElement = classElement.methods2.firstWhere((it) => it.name3 == "runBuild");
+        final resolvedLibrary = await libraryElement.session.getResolvedLibraryByElement2(libraryElement);
+        if(resolvedLibrary is! ResolvedLibraryResult) {
+          fail("Failed to resolve library");
+        }
+        final runBuildDeclaration = resolvedLibrary.getFragmentDeclaration(methodElement.firstFragment)?.node;
+        if(runBuildDeclaration == null) {
+          fail("Failed to get runBuild() method declaration");
+        }
+
+        // Run test
+        runBuildDeclaration.accept(sut);
+
+        // Verify
+        final actualReferences = sut.consumeReferences();
+        final expectedReferences = {
+          Reference("Model", "asset:package/provider.g.dart")
+        };
+        expect(actualReferences, unorderedEquals(expectedReferences));
+      });
+    });
+  });
+}


### PR DESCRIPTION
- Fixes an issue where generic type parameters (such as `List<MyCustomType>`) weren't being properly resolved in generated `runBuild` methods. This would led to errors complaining about missing types when running tests including Flumepod mocks (fixes #14).
- Adds Android Studio run configurations for tests.
- Updates `CONTRIBUTING.md` with updated information for running tests.