### PR TITLE
Relax dart sdk constraint & update change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0
+
+* Fixes an issue where notifier class family argument symbols weren't being resolved and prefixed with imports ([#21](https://github.com/Apadmi-Engineering/mirage/issues/21)).
+* Relaxes Dart SDK version constraint to `^3.9.0`.
+
 ## 1.0.0-dev.3
 
 * Updates `pubspec.yaml` for publishing to pub.dev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.0
 
 * Fixes an issue where notifier class family argument symbols weren't being resolved and prefixed with imports ([#21](https://github.com/Apadmi-Engineering/mirage/issues/21)).
+* Fixes an issue where notifiers would sometimes be destroyed part way through tests ([#24](https://github.com/Apadmi-Engineering/mirage/issues/24)).
 * Relaxes Dart SDK version constraint to `^3.9.0`.
 
 ## 1.0.0-dev.3

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -223,7 +223,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-dev.3"
+    version: "1.0.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -681,5 +681,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.9.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flumepod
 description: "A code generator to create Mockito compliant mocks of Riverpod Notifiers."
 repository: https://github.com/Apadmi-Engineering/mirage
 issue_tracker: https://github.com/Apadmi-Engineering/mirage/issues
-version: 1.0.0-dev.3
+version: 1.0.0
 topics:
   - riverpod
   - testing

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ topics:
   - mocking
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.9.0
   flutter: ">=3.0.0"
 
 dependencies:


### PR DESCRIPTION
- Relaxes Dart SDK version to `^3.9.0`.
- Updates `CHANGELOG.md`
- Rolls package version