### PR TITLE
Fix notifiers sometimes not staying alive in tests

### DIFF
--- a/lib/src/code_builders/method_code_builder.dart
+++ b/lib/src/code_builders/method_code_builder.dart
@@ -22,8 +22,6 @@ class MethodCodeBuilder {
   List<Method> generateMethods(
     ClassElement classElement, {
     bool seedValueProvided = true,
-    // TODO(TomRHandcock) Remove this field when deemed no longer required.
-    bool generateKeepAlive = false,
   }) {
     final methodElements = classElement.methods;
     final returnTypes =
@@ -32,7 +30,7 @@ class MethodCodeBuilder {
     return methodElements
         .map((methodElement) => switch (methodElement.name) {
               "build" => generateBuildMethod(
-                  methodElement, seedValueProvided, generateKeepAlive),
+                  methodElement, seedValueProvided),
               _ => generateMethod(methodElement, fakedTypes),
             })
         .whereType<Method>()
@@ -42,7 +40,6 @@ class MethodCodeBuilder {
   Method generateBuildMethod(
     MethodElement method,
     bool seedValueProvided,
-    bool generateKeepAlive,
   ) {
     final isFuture = method.returnType.isDartAsyncFuture ||
         method.returnType.isDartAsyncFutureOr;
@@ -55,9 +52,7 @@ class MethodCodeBuilder {
         methodBuilder
           ..name = "build"
           ..body = Block((blockBuilder) {
-            if (generateKeepAlive) {
-              blockBuilder.addStaticCode(_keepAliveInsert);
-            }
+            blockBuilder.addStaticCode(_keepAliveInsert);
             if (isStream) {
               blockBuilder.addStaticCode("yield* ");
             } else {

--- a/test/golden/flumepod/async_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/async_notifier/expected.flumepod.dart
@@ -33,6 +33,8 @@ class MockTestNotifier extends _i1.$AsyncNotifier<String>
 
   @override
   _i4.FutureOr<String> build() async {
+    // keepAlive() used so mock instance with stubbed/real calls isn't disposed.
+    ref.keepAlive();
     return noSuchMethod(Invocation.method(#build, []),
         returnValueForMissingStub: seedBuilder());
   }

--- a/test/golden/flumepod/auto_dispose_async_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/auto_dispose_async_notifier/expected.flumepod.dart
@@ -33,6 +33,8 @@ class MockTestNotifier extends _i1.$AsyncNotifier<String>
 
   @override
   _i4.FutureOr<String> build() async {
+    // keepAlive() used so mock instance with stubbed/real calls isn't disposed.
+    ref.keepAlive();
     return noSuchMethod(Invocation.method(#build, []),
         returnValueForMissingStub: seedBuilder());
   }

--- a/test/golden/flumepod/auto_dispose_family_async_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/auto_dispose_family_async_notifier/expected.flumepod.dart
@@ -38,6 +38,8 @@ class MockTestNotifier extends _i1.$AsyncNotifier<String>
 
   @override
   _i5.FutureOr<String> build(String? param) async {
+    // keepAlive() used so mock instance with stubbed/real calls isn't disposed.
+    ref.keepAlive();
     return noSuchMethod(Invocation.method(#build, [param]),
         returnValueForMissingStub: seedBuilder());
   }

--- a/test/golden/flumepod/auto_dispose_family_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/auto_dispose_family_notifier/expected.flumepod.dart
@@ -35,6 +35,8 @@ class MockTestNotifier extends _i1.$Notifier<String>
 
   @override
   String build(String? param) {
+    // keepAlive() used so mock instance with stubbed/real calls isn't disposed.
+    ref.keepAlive();
     return noSuchMethod(Invocation.method(#build, [param]),
         returnValueForMissingStub: seedBuilder());
   }

--- a/test/golden/flumepod/auto_dispose_family_stream_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/auto_dispose_family_stream_notifier/expected.flumepod.dart
@@ -38,6 +38,8 @@ class MockTestNotifier extends _i1.$StreamNotifier<String>
 
   @override
   _i5.Stream<String> build(String? param) async* {
+    // keepAlive() used so mock instance with stubbed/real calls isn't disposed.
+    ref.keepAlive();
     yield* noSuchMethod(Invocation.method(#build, [param]),
         returnValueForMissingStub: seedBuilder());
   }

--- a/test/golden/flumepod/auto_dispose_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/auto_dispose_notifier/expected.flumepod.dart
@@ -30,6 +30,8 @@ class MockTestNotifier extends _i1.$Notifier<String>
 
   @override
   String build() {
+    // keepAlive() used so mock instance with stubbed/real calls isn't disposed.
+    ref.keepAlive();
     return noSuchMethod(Invocation.method(#build, []),
         returnValueForMissingStub: seedBuilder());
   }

--- a/test/golden/flumepod/auto_dispose_stream_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/auto_dispose_stream_notifier/expected.flumepod.dart
@@ -33,6 +33,8 @@ class MockTestNotifier extends _i1.$StreamNotifier<String>
 
   @override
   _i4.Stream<String> build() async* {
+    // keepAlive() used so mock instance with stubbed/real calls isn't disposed.
+    ref.keepAlive();
     yield* noSuchMethod(Invocation.method(#build, []),
         returnValueForMissingStub: seedBuilder());
   }

--- a/test/golden/flumepod/family_async_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/family_async_notifier/expected.flumepod.dart
@@ -38,6 +38,8 @@ class MockTestNotifier extends _i1.$AsyncNotifier<String>
 
   @override
   _i5.FutureOr<String> build(String? param) async {
+    // keepAlive() used so mock instance with stubbed/real calls isn't disposed.
+    ref.keepAlive();
     return noSuchMethod(Invocation.method(#build, [param]),
         returnValueForMissingStub: seedBuilder());
   }

--- a/test/golden/flumepod/family_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/family_notifier/expected.flumepod.dart
@@ -37,6 +37,8 @@ class MockTestNotifier extends _i1.$Notifier<String>
 
   @override
   String build(_i7.Model? param) {
+    // keepAlive() used so mock instance with stubbed/real calls isn't disposed.
+    ref.keepAlive();
     return noSuchMethod(Invocation.method(#build, [param]),
         returnValueForMissingStub: seedBuilder());
   }

--- a/test/golden/flumepod/family_stream_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/family_stream_notifier/expected.flumepod.dart
@@ -38,6 +38,8 @@ class MockTestNotifier extends _i1.$StreamNotifier<String>
 
   @override
   _i5.Stream<String> build(String? param) async* {
+    // keepAlive() used so mock instance with stubbed/real calls isn't disposed.
+    ref.keepAlive();
     yield* noSuchMethod(Invocation.method(#build, [param]),
         returnValueForMissingStub: seedBuilder());
   }

--- a/test/golden/flumepod/notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/notifier/expected.flumepod.dart
@@ -30,6 +30,8 @@ class MockTestNotifier extends _i1.$Notifier<String>
 
   @override
   String build() {
+    // keepAlive() used so mock instance with stubbed/real calls isn't disposed.
+    ref.keepAlive();
     return noSuchMethod(Invocation.method(#build, []),
         returnValueForMissingStub: seedBuilder());
   }

--- a/test/golden/flumepod/stream_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/stream_notifier/expected.flumepod.dart
@@ -33,6 +33,8 @@ class MockTestNotifier extends _i1.$StreamNotifier<String>
 
   @override
   _i4.Stream<String> build() async* {
+    // keepAlive() used so mock instance with stubbed/real calls isn't disposed.
+    ref.keepAlive();
     yield* noSuchMethod(Invocation.method(#build, []),
         returnValueForMissingStub: seedBuilder());
   }

--- a/test/unit/code_builders/method_code_builder/method_code_builder_test.dart
+++ b/test/unit/code_builders/method_code_builder/method_code_builder_test.dart
@@ -30,7 +30,7 @@ void main() {
     });
 
     test(
-        "generateBuildMethod - async, no seed, no keep alive - returns expected method",
+        "generateBuildMethod - async, no seed - returns expected method",
         () {
       // Setup
       final parameterTypeFixture = MockDartType();
@@ -55,7 +55,7 @@ void main() {
 
       // Run test
       final result =
-          sut.generateBuildMethod(methodElementFixture, false, false);
+          sut.generateBuildMethod(methodElementFixture, false);
 
       // Verify
       expect(
@@ -102,7 +102,7 @@ void main() {
     });
 
     test(
-        "generateBuildMethod - async, seeded, keep alive - returns expected method",
+        "generateBuildMethod - async, seeded - returns expected method",
         () {
       // Setup
       final parameterTypeFixture = MockDartType();
@@ -126,7 +126,7 @@ void main() {
           .thenReturn(const Reference("Future<String>"));
 
       // Run test
-      final result = sut.generateBuildMethod(methodElementFixture, true, true);
+      final result = sut.generateBuildMethod(methodElementFixture, true);
 
       // Verify
       expect(
@@ -183,7 +183,7 @@ void main() {
     });
 
     test(
-        "generateBuildMethod - sync, no seed, no keep alive - returns expected method",
+        "generateBuildMethod - sync, no seed - returns expected method",
         () {
       // Setup
       final returnTypeFixture = MockDartType();
@@ -195,7 +195,7 @@ void main() {
 
       // Run test
       final result =
-          sut.generateBuildMethod(methodElementFixture, false, false);
+          sut.generateBuildMethod(methodElementFixture, false);
 
       // Verify
       expect(
@@ -225,7 +225,7 @@ void main() {
     });
 
     test(
-        "generateBuildMethod - stream, no seed, no keep alive - returns expected method",
+        "generateBuildMethod - stream, no seed - returns expected method",
         () {
       // Setup
       final returnTypeFixture = MockDartType();
@@ -238,7 +238,7 @@ void main() {
 
       // Run test
       final result =
-          sut.generateBuildMethod(methodElementFixture, false, false);
+          sut.generateBuildMethod(methodElementFixture, false);
 
       // Verify
       expect(


### PR DESCRIPTION
- Fixes #24 whereby notifiers would sometimes be destroyed in unit tests therefore losing previous stubs and verifications.