### PR TITLE
Update `release-tag` workflow to use GitHub app token

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -2,6 +2,7 @@ name: Tag and start release
 on:
   push:
     branches: [develop]
+  workflow_dispatch:
 
 jobs:
   publish-packages:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -12,6 +12,12 @@ jobs:
     runs-on: [ ubuntu-latest ]
     if: contains(github.event.head_commit.message, 'chore(release)')
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 #v3.1.1
+        with:
+          app-id: ${{ secrets.MELOS_APP_ID }}
+          private-key: ${{ secrets.MELOS_APP_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -19,6 +25,7 @@ jobs:
       - uses: bluefireteam/melos-action@705015c3d2bc4ab94201ac24accb2bbe070cf533 # v3.6.0
         with:
           tag: true
+          token: ${{ steps.generate-token.outputs.token }}
       - run: |
           melos exec -c 1 --no-published --no-private --order-dependents -- \
           gh workflow run release-publish.yml \


### PR DESCRIPTION
- The release tagging workflow currently doesn't have permissions to push new tags to the repository to trigger a release. This PR updates it to use the Melos app token & adds a `workflow_dispatch` trigger to enable manual runs