### PR TITLE
Implement mock accessor on provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-A generator for creating [Mockito](https://pub.dev/packages/mockito) mocks of [Riverpod](https://riverpod.dev/) notifiers for use in unit testing.
+A generator for creating [Mockito](https://pub.dev/packages/mockito) mocks
+of [Riverpod](https://riverpod.dev/) notifiers for use in unit testing.
 
 ## Why is this needed?
 
@@ -6,12 +7,12 @@ Three parts of a good unit test are:
 
 - **Setup**  - Create the context for your unit test by stubbing dependencies.
 - **Act** - Interact with your `sut` (System Under Test) in some way.
-- **Verify** - Assert the results of **act** either by checking outputs or 
-expecting interactions with other entities.
+- **Verify** - Assert the results of **act** either by checking outputs or
+  expecting interactions with other entities.
 
-Riverpod's core unit test offering doesn't include complete utilities for 
-mocking Notifiers. That's where this package comes in, it attempts to be a 
-solution to generate Mockito mocks of Riverpod Notifiers in a way that allows 
+Riverpod's core unit test offering doesn't include complete utilities for
+mocking Notifiers. That's where this package comes in, it attempts to be a
+solution to generate Mockito mocks of Riverpod Notifiers in a way that allows
 for...
 
 - Stubbing
@@ -22,76 +23,78 @@ for...
 
 The central aim of this package is that usage is similar to that of Mockito.
 
-Add the `@Flumepod` annotation on the `main` method in your unit test file, 
-this annotation takes a single, named argument, `providerTypesToMock`. The value should 
+Add the `@Flumepod` annotation on the `main` method in your unit test file,
+this annotation takes a single, named argument, `providerTypesToMock`. The value should
 be a `Set` of `Type`s that are providers.
 
 For example...
 
 `my_notifier.dart`
+
 ```dart
 class MyNotifier extends _$MyNotifier {
-    @override
-    FutureOr<State> build() async {
-        return state;
-    }
+  @override
+  FutureOr<State> build() async {
+    return state;
+  }
 
-    void performSideEffect(Object someArg) async {
-        // Do something
-    }
+  void performSideEffect(Object someArg) async {
+    // Do something
+  }
 }
 ```
 
 Generating a mock of `MyNotifier` in a unit test would look like...
 
 > [!NOTE]
-> **1.X Migration note:** Riverpod 3.X introduces [automatic retry behaviour](https://riverpod.dev/docs/whats_new#automatic-retry) whereby providers that emit errors automatically invalidate and try again. This doesn't allow you to assert error behaviour in unit testing and so it is recommended to disable automatric retries in unit tests ([see here](https://riverpod.dev/docs/concepts2/retry#disabling-retry)).
+> **1.X Migration note:** Riverpod 3.X
+> introduces [automatic retry behaviour](https://riverpod.dev/docs/whats_new#automatic-retry) whereby
+> providers that emit errors automatically invalidate and try again. This doesn't allow you to assert
+> error behaviour in unit testing and so it is recommended to disable automatric retries in unit
+> tests ([see here](https://riverpod.dev/docs/concepts2/retry#disabling-retry)).
 
 `my_other_notifier_test.dart`
+
 ```dart
 @Flumepod(providerTypesToMock: {MyNotifier})
 void main() async {
+  test("My test", () async {
+    // Override provider with mock instance.
+    final container = ProviderContainer.test(
+      overrides: [
+        myNotifierProvider.overrideWith(MockMyNotifier(() => initialState))
+      ],
+      // You'll want to disable automatic retry to assert exception behaviour.
+      retry: (_, _) => null,
+    );
 
-    test("My test", () async {
-        // Override provider with mock instance.
-        final container = ProviderContainer.test(
-            overrides: [
-                myNotifierProvider.overrideWith(MockMyNotifier(() => initialState))
-            ],
-            // You'll want to disable automatic retry to assert exception behaviour.
-            retry: (_, _) => null,
-        );
+    // To stub (with arg matchers).
+    final myNotifier = container.read(myNotifierProvider.mock);
+    when(myNotifier.performSideEffect(any)).thenAnswer((_) async {});
 
-        // To stub (with arg matchers).
-        final myNotifier = container.read(myNotifierProvider.notifier) as MockMyNotifier;
-        when(myNotifier.performSideEffect(any)).thenAnswer((_) async {});
+    // Test something here.
 
-        // Test something here.
-
-        // Verify (with arg matchers).
-        verify(myNotifier.performSideEffect(any)).called(1);
-    });
+    // Verify (with arg matchers).
+    verify(myNotifier.performSideEffect(any)).called(1);
+  });
 }
 ```
 
-Mocks are generated in the usual way with `dart run build_runner build`, or if you're 😎, `dart run build_runner watch`.
+Note the use of `.mock` to read the mock notifier instance. Unlike `.notifier`, `.mock` returns a
+cast instance of the notifier class which allows you to use Mockito's argument matchers when 
+stubbing and verifying method calls.
+
+Mocks are generated in the usual way with `dart run build_runner build`, or if you're 😎,
+`dart run build_runner watch`.
 
 ## Considerations
 
 ### Stubbing and verifications
 
-You'll need to obtain the instance of your mocked provider through the provider container (as in the above example) to ensure you are stubbing and verifying upon the *same instance*.
-
-### Argument matchers
-
-To use argument matchers such as `any`, `anyNamed`; you'll need to obtain the instance of your notifier by reading the provider container and then casting it as the mock class.
-
-```dart
-container.read(myNotifier.notifier) as MockMyNotifier
-```
-
-This is because Mockitos argument matchers are nullable, however the parameters contained in the interface of your notifier probably aren't. Flumepod solves this by making all parameters in mock classes nullable. However, when you read your notifier from the provider container, you read it "as" the original interface. Hence, the need to cast it as the mocked version (because it is).
+You'll need to obtain the instance of your mocked provider through the provider container (as in the
+above example) to ensure you are stubbing and verifying upon the *same instance*.
 
 ## Problems
 
-If something isn't working, preferably report it [here](https://github.com/Apadmi-Engineering/mirage/issues). Contributions are welcome!
+If something isn't working, preferably report
+it [here](https://github.com/Apadmi-Engineering/mirage/issues). Contributions are welcome!

--- a/example/test/unit/notifier/notifier_test.dart
+++ b/example/test/unit/notifier/notifier_test.dart
@@ -1,7 +1,7 @@
 import 'package:flumepod/flumepod.dart';
 import 'package:flumepod_example/src/notifiers/notifier/notifier.dart';
 import 'package:mockito/mockito.dart';
-import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:riverpod/riverpod.dart';
 import 'package:test/test.dart';
 
 import 'notifier_test.flumepod.dart';
@@ -15,7 +15,7 @@ void main() async {
         () => MockDummySource(() async => 36),
       )
     ]);
-    final mockDummySource = container.read(dummySourceProvider(6).notifier) as MockDummySource;
+    final mockDummySource = container.read(dummySourceProvider(6).mock);
     when(mockDummySource.dummy).thenReturn("Hello!");
 
     // Run test

--- a/lib/src/code_builders/classes/class_code_builder.dart
+++ b/lib/src/code_builders/classes/class_code_builder.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:code_builder/code_builder.dart';
@@ -39,11 +40,22 @@ mixin ClassCodeBuilderUtils {
 
   ClassElement getClassForType(DartType type) {
     final library = getLibraryForType(type);
-    final classElement =
-        LibraryReader(library).element.getClass(getTypeName(type));
+    final classElement = LibraryReader(
+      library,
+    ).element.getClass(getTypeName(type));
     if (classElement == null) {
       throw ClassNotFound(type);
     }
     return classElement;
+  }
+
+  Future<ResolvedLibraryResult> getResolvedClass(ClassElement element) async {
+    final resolvedClass = await element.session?.getResolvedLibraryByElement(
+      element.library,
+    );
+    if (resolvedClass is! ResolvedLibraryResult) {
+      throw StateError("Unable to resolve library for class");
+    }
+    return resolvedClass;
   }
 }

--- a/lib/src/code_builders/classes/class_code_builder.dart
+++ b/lib/src/code_builders/classes/class_code_builder.dart
@@ -6,8 +6,8 @@ import 'package:code_builder/code_builder.dart';
 import 'package:flumepod/src/models/errors.dart';
 import 'package:source_gen/source_gen.dart';
 
-abstract class ClassCodeBuilderDelegate {
-  FutureOr<List<Class>> generate(DartType type);
+abstract class SpecCodeBuilderDelegate {
+  FutureOr<List<Spec>> generate(DartType type);
 }
 
 mixin ClassCodeBuilderUtils {

--- a/lib/src/code_builders/classes/notifier_class_builder.dart
+++ b/lib/src/code_builders/classes/notifier_class_builder.dart
@@ -13,7 +13,7 @@ import 'package:flumepod/src/type_referencer.dart';
 
 class NotifierClassBuilder
     with ClassCodeBuilderUtils
-    implements ClassCodeBuilderDelegate {
+    implements SpecCodeBuilderDelegate {
   final FakeTypeCodeBuilder _fakeTypeCodeBuilder;
   final Function(ResolvedLibraryResult result) _getMemberCopier;
   final ImportFinder _importFinder;
@@ -31,18 +31,24 @@ class NotifierClassBuilder
   );
 
   @override
-  Future<List<Class>> generate(analyzer.DartType type) async {
+  Future<List<Spec>> generate(analyzer.DartType type) async {
     final classElement = getClassForType(type);
     final fakeTypes = _generateFakeTypes(classElement);
 
     final notifier = await _getNotifierClass(classElement, fakeTypes);
+    final mockAccessor = await _getMockNotifierAccessor(classElement);
     final fakedClasses = _generateFakeClasses(fakeTypes) ?? [];
-    return fakedClasses + [notifier];
+    return fakedClasses.cast<Spec>() + [notifier, mockAccessor];
   }
 
-  Future<Class> _getNotifierClass(ClassElement element, Set<FakeType> fakeTypes) async {
-    final resolvedResult = await element.session?.getResolvedLibraryByElement(element.library);
-    if(resolvedResult is! ResolvedLibraryResult) {
+  Future<Class> _getNotifierClass(
+    ClassElement element,
+    Set<FakeType> fakeTypes,
+  ) async {
+    final resolvedResult = await element.session?.getResolvedLibraryByElement(
+      element.library,
+    );
+    if (resolvedResult is! ResolvedLibraryResult) {
       throw StateError("Unable to resolve library for class");
     }
     final memberCopier = _getMemberCopier(resolvedResult);
@@ -62,22 +68,25 @@ class NotifierClassBuilder
 
       for (final GetterElement getter in element.supertype?.getters ?? []) {
         final copiedGetter = memberCopier.copyGetter(getter);
-        if(copiedGetter != null) {
+        if (copiedGetter != null) {
           classBuilder.methods.add(copiedGetter);
         }
       }
 
-      for (final FieldElement field in element.supertype?.element.fields ?? []) {
+      for (final FieldElement field
+          in element.supertype?.element.fields ?? []) {
         final copiedField = memberCopier.copyField(field);
-        if(copiedField != null) {
+        if (copiedField != null) {
           classBuilder.fields.add(copiedField);
         }
       }
 
-      final runBuildMethod = element.supertype?.element.methods.where((method) => method.name == "runBuild").firstOrNull;
-      if(runBuildMethod != null) {
+      final runBuildMethod = element.supertype?.element.methods
+          .where((method) => method.name == "runBuild")
+          .firstOrNull;
+      if (runBuildMethod != null) {
         final copiedMethod = memberCopier.copyMethod(runBuildMethod, true);
-        if(copiedMethod != null) {
+        if (copiedMethod != null) {
           classBuilder.methods.add(copiedMethod);
         }
       }
@@ -89,21 +98,28 @@ class NotifierClassBuilder
           Field(
             (field) => field
               ..name = "seedBuilder"
-              ..type = (FunctionTypeBuilder()
-                    ..update(
-                      (function) => function
-                        ..returnType =
-                            _typeReferencer.obtainReferenceForType(seedType),
-                    ))
-                  .build(),
+              ..type =
+                  (FunctionTypeBuilder()..update(
+                        (function) => function
+                          ..returnType = _typeReferencer.obtainReferenceForType(
+                            seedType,
+                          ),
+                      ))
+                      .build(),
           ),
         );
-        classBuilder.constructors.add(Constructor((constructor) => constructor
-          ..requiredParameters.add(Parameter(
-            (param) => param
-              ..toThis = true
-              ..name = "seedBuilder",
-          ))));
+        classBuilder.constructors.add(
+          Constructor(
+            (constructor) => constructor
+              ..requiredParameters.add(
+                Parameter(
+                  (param) => param
+                    ..toThis = true
+                    ..name = "seedBuilder",
+                ),
+              ),
+          ),
+        );
       }
       // Add stubbed method overrides.
       classBuilder.methods.addAll(
@@ -115,9 +131,43 @@ class NotifierClassBuilder
     });
   }
 
+  Future<Extension> _getMockNotifierAccessor(ClassElement element) async {
+    final resolvedClass = await element.session?.getResolvedLibraryByElement(
+      element.library,
+    );
+    if (resolvedClass is! ResolvedLibraryResult) {
+      throw StateError("Unable to resolve library for class");
+    }
+    final notifierTypeName = getTypeName(element.thisType);
+    return Extension((eb) {
+      eb.name = "Mock${notifierTypeName}Accessor";
+      eb.on = refer("${notifierTypeName}Provider", resolvedClass.element.uri.toString());
+      eb.methods.add(
+        Method((mb) {
+          mb.name = "mock";
+          mb.type = MethodType.getter;
+          mb.returns = TypeReference(
+            (tb) => tb
+              ..symbol = "ProviderListenable"
+              ..url = "package:riverpod/misc.dart"
+              ..types.add(Reference("Mock$notifierTypeName")),
+          );
+          mb.body = Code.scope((refer) {
+            refer(Reference("select", "package:riverpod/riverpod.dart"));
+            return "return notifier.select((it) => it as Mock$notifierTypeName);";
+          });
+        }),
+      );
+    });
+  }
+
   Set<FakeType> _generateFakeTypes(ClassElement classElement) {
-    final publicMethods = classElement.methods.where((method) => method.isPublic);
-    final returnTypes = publicMethods.map((method) => method.returnType).toSet();
+    final publicMethods = classElement.methods.where(
+      (method) => method.isPublic,
+    );
+    final returnTypes = publicMethods
+        .map((method) => method.returnType)
+        .toSet();
     return _fakeTypeCodeBuilder.generateFakeTypes(returnTypes);
   }
 
@@ -125,9 +175,9 @@ class NotifierClassBuilder
     final fakes = fakeTypes.where((fakeType) => fakeType.fakeTypeName != null);
     return fakes.isNotEmpty
         ? fakes
-            .map((type) => _fakeTypeCodeBuilder.buildFakeClass(type))
-            .whereType<Class>()
-            .toList()
+              .map((type) => _fakeTypeCodeBuilder.buildFakeClass(type))
+              .whereType<Class>()
+              .toList()
         : null;
   }
 }

--- a/lib/src/code_builders/classes/notifier_class_builder.dart
+++ b/lib/src/code_builders/classes/notifier_class_builder.dart
@@ -45,12 +45,7 @@ class NotifierClassBuilder
     ClassElement element,
     Set<FakeType> fakeTypes,
   ) async {
-    final resolvedResult = await element.session?.getResolvedLibraryByElement(
-      element.library,
-    );
-    if (resolvedResult is! ResolvedLibraryResult) {
-      throw StateError("Unable to resolve library for class");
-    }
+    final resolvedResult = await getResolvedClass(element);
     final memberCopier = _getMemberCopier(resolvedResult);
     return Class((classBuilder) {
       final typeName = getTypeName(element.thisType);
@@ -132,33 +127,32 @@ class NotifierClassBuilder
   }
 
   Future<Extension> _getMockNotifierAccessor(ClassElement element) async {
-    final resolvedClass = await element.session?.getResolvedLibraryByElement(
-      element.library,
-    );
-    if (resolvedClass is! ResolvedLibraryResult) {
-      throw StateError("Unable to resolve library for class");
-    }
+    final resolvedClass = await getResolvedClass(element);
     final notifierTypeName = getTypeName(element.thisType);
-    return Extension((eb) {
-      eb.name = "Mock${notifierTypeName}Accessor";
-      eb.on = refer("${notifierTypeName}Provider", resolvedClass.element.uri.toString());
-      eb.methods.add(
-        Method((mb) {
-          mb.name = "mock";
-          mb.type = MethodType.getter;
-          mb.returns = TypeReference(
-            (tb) => tb
-              ..symbol = "ProviderListenable"
-              ..url = "package:riverpod/misc.dart"
-              ..types.add(Reference("Mock$notifierTypeName")),
-          );
-          mb.body = Code.scope((refer) {
-            refer(Reference("select", "package:riverpod/riverpod.dart"));
-            return "return notifier.select((it) => it as Mock$notifierTypeName);";
-          });
-        }),
-      );
-    });
+    return Extension(
+      (eb) => eb
+        ..name = "Mock${notifierTypeName}Accessor"
+        ..on = refer(
+          "${notifierTypeName}Provider",
+          resolvedClass.element.uri.toString(),
+        )
+        ..methods.add(
+          Method((mb) {
+            mb.name = "mock";
+            mb.type = MethodType.getter;
+            mb.returns = TypeReference(
+              (tb) => tb
+                ..symbol = "ProviderListenable"
+                ..url = "package:riverpod/misc.dart"
+                ..types.add(Reference("Mock$notifierTypeName")),
+            );
+            mb.body = Code.scope((refer) {
+              refer(Reference("select", "package:riverpod/riverpod.dart"));
+              return "return notifier.select((it) => it as Mock$notifierTypeName);";
+            });
+          }),
+        ),
+    );
   }
 
   Set<FakeType> _generateFakeTypes(ClassElement classElement) {

--- a/test/golden/flumepod/async_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/async_notifier/expected.flumepod.dart
@@ -9,6 +9,9 @@ import 'input.dart' as _i3;
 import 'dart:async' as _i4;
 import 'package:riverpod/src/framework.dart' as _i5;
 import 'package:mockito/src/dummies.dart' as _i6;
+import 'asset:flumepod/test/input.dart' as _i7;
+import 'package:riverpod/misc.dart' as _i8;
+import 'package:riverpod/riverpod.dart' as _i9;
 
 // Flumepod generated mock of class [TestNotifier].
 class MockTestNotifier extends _i1.$AsyncNotifier<(String, String)>
@@ -74,5 +77,11 @@ class MockTestNotifier extends _i1.$AsyncNotifier<(String, String)>
     return noSuchMethod(
       Invocation.method(#asyncSideEffect, []),
     );
+  }
+}
+
+extension MockTestNotifierAccessor on _i7.TestNotifierProvider {
+  _i8.ProviderListenable<MockTestNotifier> get mock {
+    return notifier.select((it) => it as MockTestNotifier);
   }
 }

--- a/test/golden/flumepod/auto_dispose_async_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/auto_dispose_async_notifier/expected.flumepod.dart
@@ -9,6 +9,9 @@ import 'input.dart' as _i3;
 import 'dart:async' as _i4;
 import 'package:riverpod/src/framework.dart' as _i5;
 import 'package:mockito/src/dummies.dart' as _i6;
+import 'asset:flumepod/test/input.dart' as _i7;
+import 'package:riverpod/misc.dart' as _i8;
+import 'package:riverpod/riverpod.dart' as _i9;
 
 // Flumepod generated mock of class [TestNotifier].
 class MockTestNotifier extends _i1.$AsyncNotifier<String>
@@ -73,5 +76,11 @@ class MockTestNotifier extends _i1.$AsyncNotifier<String>
     return noSuchMethod(
       Invocation.method(#asyncSideEffect, []),
     );
+  }
+}
+
+extension MockTestNotifierAccessor on _i7.TestNotifierProvider {
+  _i8.ProviderListenable<MockTestNotifier> get mock {
+    return notifier.select((it) => it as MockTestNotifier);
   }
 }

--- a/test/golden/flumepod/auto_dispose_family_async_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/auto_dispose_family_async_notifier/expected.flumepod.dart
@@ -10,6 +10,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart' as _i4;
 import 'dart:async' as _i5;
 import 'package:riverpod/src/framework.dart' as _i6;
 import 'package:mockito/src/dummies.dart' as _i7;
+import 'asset:flumepod/test/input.dart' as _i8;
+import 'package:riverpod/misc.dart' as _i9;
+import 'package:riverpod/riverpod.dart' as _i10;
 
 // Flumepod generated mock of class [TestNotifier].
 class MockTestNotifier extends _i1.$AsyncNotifier<String>
@@ -78,5 +81,11 @@ class MockTestNotifier extends _i1.$AsyncNotifier<String>
     return noSuchMethod(
       Invocation.method(#asyncSideEffect, []),
     );
+  }
+}
+
+extension MockTestNotifierAccessor on _i8.TestNotifierProvider {
+  _i9.ProviderListenable<MockTestNotifier> get mock {
+    return notifier.select((it) => it as MockTestNotifier);
   }
 }

--- a/test/golden/flumepod/auto_dispose_family_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/auto_dispose_family_notifier/expected.flumepod.dart
@@ -10,6 +10,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart' as _i4;
 import 'package:riverpod/src/framework.dart' as _i5;
 import 'package:mockito/src/dummies.dart' as _i6;
 import 'dart:async' as _i7;
+import 'asset:flumepod/test/input.dart' as _i8;
+import 'package:riverpod/misc.dart' as _i9;
+import 'package:riverpod/riverpod.dart' as _i10;
 
 // Flumepod generated mock of class [TestNotifier].
 class MockTestNotifier extends _i1.$Notifier<String>
@@ -75,5 +78,11 @@ class MockTestNotifier extends _i1.$Notifier<String>
     return noSuchMethod(
       Invocation.method(#asyncSideEffect, []),
     );
+  }
+}
+
+extension MockTestNotifierAccessor on _i8.TestNotifierProvider {
+  _i9.ProviderListenable<MockTestNotifier> get mock {
+    return notifier.select((it) => it as MockTestNotifier);
   }
 }

--- a/test/golden/flumepod/auto_dispose_family_stream_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/auto_dispose_family_stream_notifier/expected.flumepod.dart
@@ -10,6 +10,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart' as _i4;
 import 'dart:async' as _i5;
 import 'package:riverpod/src/framework.dart' as _i6;
 import 'package:mockito/src/dummies.dart' as _i7;
+import 'asset:flumepod/test/input.dart' as _i8;
+import 'package:riverpod/misc.dart' as _i9;
+import 'package:riverpod/riverpod.dart' as _i10;
 
 // Flumepod generated mock of class [TestNotifier].
 class MockTestNotifier extends _i1.$StreamNotifier<String>
@@ -78,5 +81,11 @@ class MockTestNotifier extends _i1.$StreamNotifier<String>
     return noSuchMethod(
       Invocation.method(#asyncSideEffect, []),
     );
+  }
+}
+
+extension MockTestNotifierAccessor on _i8.TestNotifierProvider {
+  _i9.ProviderListenable<MockTestNotifier> get mock {
+    return notifier.select((it) => it as MockTestNotifier);
   }
 }

--- a/test/golden/flumepod/auto_dispose_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/auto_dispose_notifier/expected.flumepod.dart
@@ -9,6 +9,9 @@ import 'input.dart' as _i3;
 import 'package:riverpod/src/framework.dart' as _i4;
 import 'package:mockito/src/dummies.dart' as _i5;
 import 'dart:async' as _i6;
+import 'asset:flumepod/test/input.dart' as _i7;
+import 'package:riverpod/misc.dart' as _i8;
+import 'package:riverpod/riverpod.dart' as _i9;
 
 // Flumepod generated mock of class [TestNotifier].
 class MockTestNotifier extends _i1.$Notifier<String>
@@ -70,5 +73,11 @@ class MockTestNotifier extends _i1.$Notifier<String>
     return noSuchMethod(
       Invocation.method(#asyncSideEffect, []),
     );
+  }
+}
+
+extension MockTestNotifierAccessor on _i7.TestNotifierProvider {
+  _i8.ProviderListenable<MockTestNotifier> get mock {
+    return notifier.select((it) => it as MockTestNotifier);
   }
 }

--- a/test/golden/flumepod/auto_dispose_stream_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/auto_dispose_stream_notifier/expected.flumepod.dart
@@ -9,6 +9,9 @@ import 'input.dart' as _i3;
 import 'dart:async' as _i4;
 import 'package:riverpod/src/framework.dart' as _i5;
 import 'package:mockito/src/dummies.dart' as _i6;
+import 'asset:flumepod/test/input.dart' as _i7;
+import 'package:riverpod/misc.dart' as _i8;
+import 'package:riverpod/riverpod.dart' as _i9;
 
 // Flumepod generated mock of class [TestNotifier].
 class MockTestNotifier extends _i1.$StreamNotifier<String>
@@ -73,5 +76,11 @@ class MockTestNotifier extends _i1.$StreamNotifier<String>
     return noSuchMethod(
       Invocation.method(#asyncSideEffect, []),
     );
+  }
+}
+
+extension MockTestNotifierAccessor on _i7.TestNotifierProvider {
+  _i8.ProviderListenable<MockTestNotifier> get mock {
+    return notifier.select((it) => it as MockTestNotifier);
   }
 }

--- a/test/golden/flumepod/family_async_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/family_async_notifier/expected.flumepod.dart
@@ -10,6 +10,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart' as _i4;
 import 'dart:async' as _i5;
 import 'package:riverpod/src/framework.dart' as _i6;
 import 'package:mockito/src/dummies.dart' as _i7;
+import 'asset:flumepod/test/input.dart' as _i8;
+import 'package:riverpod/misc.dart' as _i9;
+import 'package:riverpod/riverpod.dart' as _i10;
 
 // Flumepod generated mock of class [TestNotifier].
 class MockTestNotifier extends _i1.$AsyncNotifier<String>
@@ -78,5 +81,11 @@ class MockTestNotifier extends _i1.$AsyncNotifier<String>
     return noSuchMethod(
       Invocation.method(#asyncSideEffect, []),
     );
+  }
+}
+
+extension MockTestNotifierAccessor on _i8.TestNotifierProvider {
+  _i9.ProviderListenable<MockTestNotifier> get mock {
+    return notifier.select((it) => it as MockTestNotifier);
   }
 }

--- a/test/golden/flumepod/family_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/family_notifier/expected.flumepod.dart
@@ -12,6 +12,9 @@ import 'package:riverpod/src/framework.dart' as _i6;
 import 'model.dart' as _i7;
 import 'package:mockito/src/dummies.dart' as _i8;
 import 'dart:async' as _i9;
+import 'asset:flumepod/test/input.dart' as _i10;
+import 'package:riverpod/misc.dart' as _i11;
+import 'package:riverpod/riverpod.dart' as _i12;
 
 // Flumepod generated mock of class [TestNotifier].
 class MockTestNotifier extends _i1.$Notifier<String>
@@ -77,5 +80,11 @@ class MockTestNotifier extends _i1.$Notifier<String>
     return noSuchMethod(
       Invocation.method(#asyncSideEffect, []),
     );
+  }
+}
+
+extension MockTestNotifierAccessor on _i10.TestNotifierProvider {
+  _i11.ProviderListenable<MockTestNotifier> get mock {
+    return notifier.select((it) => it as MockTestNotifier);
   }
 }

--- a/test/golden/flumepod/family_stream_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/family_stream_notifier/expected.flumepod.dart
@@ -10,6 +10,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart' as _i4;
 import 'dart:async' as _i5;
 import 'package:riverpod/src/framework.dart' as _i6;
 import 'package:mockito/src/dummies.dart' as _i7;
+import 'asset:flumepod/test/input.dart' as _i8;
+import 'package:riverpod/misc.dart' as _i9;
+import 'package:riverpod/riverpod.dart' as _i10;
 
 // Flumepod generated mock of class [TestNotifier].
 class MockTestNotifier extends _i1.$StreamNotifier<String>
@@ -78,5 +81,11 @@ class MockTestNotifier extends _i1.$StreamNotifier<String>
     return noSuchMethod(
       Invocation.method(#asyncSideEffect, []),
     );
+  }
+}
+
+extension MockTestNotifierAccessor on _i8.TestNotifierProvider {
+  _i9.ProviderListenable<MockTestNotifier> get mock {
+    return notifier.select((it) => it as MockTestNotifier);
   }
 }

--- a/test/golden/flumepod/notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/notifier/expected.flumepod.dart
@@ -9,6 +9,9 @@ import 'input.dart' as _i3;
 import 'package:riverpod/src/framework.dart' as _i4;
 import 'package:mockito/src/dummies.dart' as _i5;
 import 'dart:async' as _i6;
+import 'asset:flumepod/test/input.dart' as _i7;
+import 'package:riverpod/misc.dart' as _i8;
+import 'package:riverpod/riverpod.dart' as _i9;
 
 // Flumepod generated mock of class [TestNotifier].
 class MockTestNotifier extends _i1.$Notifier<String>
@@ -80,5 +83,11 @@ class MockTestNotifier extends _i1.$Notifier<String>
     return noSuchMethod(
       Invocation.method(#asyncSideEffect, []),
     );
+  }
+}
+
+extension MockTestNotifierAccessor on _i7.TestNotifierProvider {
+  _i8.ProviderListenable<MockTestNotifier> get mock {
+    return notifier.select((it) => it as MockTestNotifier);
   }
 }

--- a/test/golden/flumepod/stream_notifier/expected.flumepod.dart
+++ b/test/golden/flumepod/stream_notifier/expected.flumepod.dart
@@ -9,6 +9,9 @@ import 'input.dart' as _i3;
 import 'dart:async' as _i4;
 import 'package:riverpod/src/framework.dart' as _i5;
 import 'package:mockito/src/dummies.dart' as _i6;
+import 'asset:flumepod/test/input.dart' as _i7;
+import 'package:riverpod/misc.dart' as _i8;
+import 'package:riverpod/riverpod.dart' as _i9;
 
 // Flumepod generated mock of class [TestNotifier].
 class MockTestNotifier extends _i1.$StreamNotifier<String>
@@ -73,5 +76,11 @@ class MockTestNotifier extends _i1.$StreamNotifier<String>
     return noSuchMethod(
       Invocation.method(#asyncSideEffect, []),
     );
+  }
+}
+
+extension MockTestNotifierAccessor on _i7.TestNotifierProvider {
+  _i8.ProviderListenable<MockTestNotifier> get mock {
+    return notifier.select((it) => it as MockTestNotifier);
   }
 }

--- a/test/unit/code_builders/class_code_builder/class_code_builder_test.dart
+++ b/test/unit/code_builders/class_code_builder/class_code_builder_test.dart
@@ -1,0 +1,59 @@
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/analysis/session.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:flumepod/src/code_builders/classes/class_code_builder.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../../util/stubbing_utils.dart';
+import 'class_code_builder_test.mocks.dart';
+
+class FakeClassCodeBuilder with ClassCodeBuilderUtils {}
+
+@GenerateNiceMocks([
+  MockSpec<ClassElement>(),
+  MockSpec<AnalysisSession>(),
+  MockSpec<ResolvedLibraryResult>(),
+])
+void main() async {
+  group("Class code builder utils unit tests", () {
+    late FakeClassCodeBuilder sut;
+
+    setUp(() {
+      sut = FakeClassCodeBuilder();
+    });
+
+    test("getResolvedClass - upon unsuccessful result - throws", () async {
+      final fakeResult = CannotResolveUriResult();
+      final mockSession = MockAnalysisSession()
+        ..stubAnswerAsync(
+          (it) => it.getResolvedLibraryByElement(any),
+          fakeResult,
+        );
+      final mockClass = MockClassElement()
+        ..stubReturn((it) => it.session, mockSession);
+
+      await expectLater(
+        () => sut.getResolvedClass(mockClass),
+        throwsStateError,
+      );
+    });
+
+    test("getResolvedClass - upon success result - answers result", () async {
+      final fakeResult = MockResolvedLibraryResult();
+      final mockSession = MockAnalysisSession()
+        ..stubAnswerAsync(
+          (it) => it.getResolvedLibraryByElement(any),
+          fakeResult,
+        );
+      final mockClass = MockClassElement()
+        ..stubReturn((it) => it.session, mockSession);
+
+      await expectLater(
+        sut.getResolvedClass(mockClass),
+        completion(fakeResult),
+      );
+    });
+  });
+}

--- a/test/unit/util/stubbing_utils.dart
+++ b/test/unit/util/stubbing_utils.dart
@@ -3,14 +3,17 @@ import 'package:mockito/mockito.dart';
 extension InlineStubbing<T> on T {
   void stubReturn<S>(S Function(T) invocation, S stub) =>
       when(invocation(this)).thenReturn(stub);
+
+  void stubAnswerAsync<S>(Future<S> Function(T) invocation, S stub) =>
+      when(invocation(this)).thenAnswer((_) async => stub);
 }
 
 class Lazy<T> {
   T? _instance;
   final T Function() _create;
-  
+
   Lazy(this._create);
-  
+
   T call() {
     _instance ??= _create();
     return _instance!;


### PR DESCRIPTION
Implements a `.mock` accessor extension on the Riverpod-generated provider class. This acts as a shortcut for retrieving the notifier class from the provider container and casting it to the mocked class. Allows unit tests to be a bit more concise.

The original issue included a suggestion to put this behind a feature flag in the `build.yaml` file. This was motivated by the first pass at this feature using internal Riverpod APIs which I wasn't really a fan of. This implementation, which simply uses the [`.select` decorator/modifier](https://riverpod.dev/docs/how_to/select#filtering-widgetprovider-rebuild-using-select), uses only public APIs so there isn't a possibility of this breaking and therefore I don't see a need to stick this behind a feature flag.

This isn't a breaking change and is opt-in by the nature of only adding an API.

Closes #43.